### PR TITLE
Add DevelopmentDependency

### DIFF
--- a/StringLiteralGenerator.sln
+++ b/StringLiteralGenerator.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StringLiteralSample", "samp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StringLiteralCodeAnalysisSample", "samples\StringLiteralCodeAnalysisSample\StringLiteralCodeAnalysisSample.csproj", "{003A89BC-3FE1-4D6A-833C-A27363C01732}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringLiteralGenerator.Roslyn3", "src\StringLiteralGenerator.Roslyn3\StringLiteralGenerator.Roslyn3.csproj", "{41777618-F1CE-4FFF-9BBE-D00281FB262C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{003A89BC-3FE1-4D6A-833C-A27363C01732}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{003A89BC-3FE1-4D6A-833C-A27363C01732}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{003A89BC-3FE1-4D6A-833C-A27363C01732}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41777618-F1CE-4FFF-9BBE-D00281FB262C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41777618-F1CE-4FFF-9BBE-D00281FB262C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41777618-F1CE-4FFF-9BBE-D00281FB262C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41777618-F1CE-4FFF-9BBE-D00281FB262C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -37,6 +43,7 @@ Global
 		{6FD4C22B-E18F-452C-8F23-9B5F15F5E315} = {FFC2158D-94DD-4C93-8A33-84F0CE809100}
 		{BDD784F2-E65F-4774-8D2B-8536EFB94A32} = {11C3645F-EE4F-4D2A-8E69-1A287D631B51}
 		{003A89BC-3FE1-4D6A-833C-A27363C01732} = {11C3645F-EE4F-4D2A-8E69-1A287D631B51}
+		{41777618-F1CE-4FFF-9BBE-D00281FB262C} = {FFC2158D-94DD-4C93-8A33-84F0CE809100}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B11D44BB-40B7-42AD-B345-C93A42268AE1}

--- a/samples/StringLiteralCodeAnalysisSample/Program.cs
+++ b/samples/StringLiteralCodeAnalysisSample/Program.cs
@@ -78,7 +78,7 @@ namespace Sample
 
     private static Compilation Compile(string source)
     {
-        var opt = new CSharpParseOptions(languageVersion: LanguageVersion.Preview, kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Parse);
+        var opt = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp10, kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Parse);
         var copt = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
 
         var dotnetCoreDirectory = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();

--- a/samples/StringLiteralCodeAnalysisSample/StringLiteralCodeAnalysisSample.csproj
+++ b/samples/StringLiteralCodeAnalysisSample/StringLiteralCodeAnalysisSample.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-4.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/StringLiteralSample/StringLiteralSample.csproj
+++ b/samples/StringLiteralSample/StringLiteralSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,33 @@
+<Project>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>10</LangVersion>
+        <Nullable>enable</Nullable>
+        <IsRoslynComponent>true</IsRoslynComponent>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <Deterministic>true</Deterministic>
+        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+        <RootNamespace>StringLiteralGenerator</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="System"/>
+        <Using Include="System.Linq"/>
+        <Using Include="System.Text"/>
+        <Using Include="System.Collections.Generic"/>
+        <Using Include="System.Collections.Immutable"/>
+        <Using Include="System.Threading"/>
+        <Using Include="Microsoft.CodeAnalysis" />
+        <Using Include="Microsoft.CodeAnalysis.CSharp" />
+        <Using Include="Microsoft.CodeAnalysis.CSharp.Syntax" />
+        <Using Include="Microsoft.CodeAnalysis.Diagnostics" />
+        <Using Include="Microsoft.CodeAnalysis.Text" />
+    </ItemGroup>
+</Project>

--- a/src/StringLiteralGenerator.Roslyn3/Receiver.cs
+++ b/src/StringLiteralGenerator.Roslyn3/Receiver.cs
@@ -1,0 +1,25 @@
+﻿namespace StringLiteralGenerator;
+
+public partial class Utf8StringLiteralGenerator
+{
+    private sealed class Receiver : ISyntaxContextReceiver
+    {
+        public readonly List<Utf8LiteralMethod> Methods = new();
+
+        public void OnVisitSyntaxNode(GeneratorSyntaxContext context)
+        {
+            if (!IsSyntaxTargetForGeneration(context.Node))
+            {
+                return;
+            }
+
+            var value = GetSemanticTargetForGeneration(context.SemanticModel, (MethodDeclarationSyntax)context.Node);
+            if (value is null)
+            {
+                return;
+            }
+
+            Methods.Add(value);
+        }
+    }
+}

--- a/src/StringLiteralGenerator.Roslyn3/StringLiteralGenerator.Roslyn3.csproj
+++ b/src/StringLiteralGenerator.Roslyn3/StringLiteralGenerator.Roslyn3.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" PrivateAssets="all" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../$(RootNamespace)/*.cs" Exclude="../$(RootNamespace)/Utf8StringLiteralGenerator.cs" />
+	</ItemGroup>
+</Project>

--- a/src/StringLiteralGenerator.Roslyn3/Utf8StringLiteralGenerator.cs
+++ b/src/StringLiteralGenerator.Roslyn3/Utf8StringLiteralGenerator.cs
@@ -1,0 +1,35 @@
+﻿namespace StringLiteralGenerator;
+
+[Generator(LanguageNames.CSharp)]
+public partial class Utf8StringLiteralGenerator : ISourceGenerator
+{
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (context.SyntaxContextReceiver is not Receiver receiver)
+        {
+            return;
+        }
+
+        var buffer = new StringBuilder();
+        var group = receiver.Methods.GroupBy(x => x.Type, x => x.Method);
+
+        foreach (var g in group)
+        {
+            var containingType = g.Key;
+            var generatedSource = Generate(containingType, g, buffer);
+            var filename = GetFilename(containingType, buffer);
+            context.AddSource(filename, SourceText.From(generatedSource, Encoding.UTF8));
+        }
+    }
+
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        context.RegisterForPostInitialization(AddAttribute);
+        context.RegisterForSyntaxNotifications(() => new Receiver());
+    }
+
+    private static void AddAttribute(GeneratorPostInitializationContext context)
+    {
+        context.AddSource("Utf8Attribute", SourceText.From(attributeText, Encoding.UTF8));
+    }
+}

--- a/src/StringLiteralGenerator/StringLiteralGenerator.csproj
+++ b/src/StringLiteralGenerator/StringLiteralGenerator.csproj
@@ -1,32 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsRoslynComponent>true</IsRoslynComponent>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+	<PropertyGroup>
+		<DevelopmentDependency>true</DevelopmentDependency>
+		<PackageId>StringLiteralGenerator</PackageId>
+		<Authors>Nobuyuki Iwanaga</Authors>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<RepositoryUrl>https://github.com/ufcpp/StringLiteralGenerator</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<Description>A C# Source Generator for optimizing UTF-8 binaries.</Description>
+	</PropertyGroup>
 
-    <PackageId>StringLiteralGenerator</PackageId>
-    <Authors>Nobuyuki Iwanaga</Authors>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/ufcpp/StringLiteralGenerator</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>A C# Source Generator for optimizing UTF-8 binaries.</Description>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+	</ItemGroup>
 
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
-  </PropertyGroup>
+	<ItemGroup>
+		<!-- Package the generator in the analyzer directory of the nuget package -->
+		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.0/cs" Visible="false" />
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.0-4.final" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-  </ItemGroup>
+		<!-- Package the props file -->
+		<Content Include="build\$(RootNamespace).targets" Pack="true" PackagePath="build" />
+	</ItemGroup>
 
-  <Target Name="_AddAnalyzersToOutput">
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\StringLiteralGenerator.dll" PackagePath="analyzers/dotnet/cs" />
-    </ItemGroup>
-  </Target>
+	<Target Name="_AddAnalyzersToOutput" BeforeTargets="_GetPackageFiles">
+		<MSBuild Projects="../$(RootNamespace).Roslyn3/$(RootNamespace).Roslyn3.csproj" Targets="GetTargetPath">
+			<Output ItemName="Roslyn3Assembly" TaskParameter="TargetOutputs" />
+		</MSBuild>
+
+		<ItemGroup>
+			<None Include="%(Roslyn3Assembly.Identity)" Pack="true" PackagePath="analyzers/dotnet/roslyn3.11/cs" Visible="false" />
+		</ItemGroup>
+	</Target>
 
 </Project>

--- a/src/StringLiteralGenerator/TypeInfo.cs
+++ b/src/StringLiteralGenerator/TypeInfo.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-
-namespace StringLiteralGenerator;
+﻿namespace StringLiteralGenerator;
 
 public partial class Utf8StringLiteralGenerator
 {

--- a/src/StringLiteralGenerator/Utf8StringLiteralGenerator.Emitter.cs
+++ b/src/StringLiteralGenerator/Utf8StringLiteralGenerator.Emitter.cs
@@ -1,30 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-
-namespace StringLiteralGenerator;
+﻿namespace StringLiteralGenerator;
 
 public partial class Utf8StringLiteralGenerator
 {
-    private static void Emit(SourceProductionContext context, ImmutableArray<Utf8LiteralMethod> methods)
-    {
-        var buffer = new StringBuilder();
-
-        var group = methods.GroupBy(x => x.Type, x => x.Method);
-
-        foreach (var g in group)
-        {
-            var containingType = g.Key;
-            var generatedSource = Generate(containingType, g, buffer);
-            var filename = GetFilename(containingType, buffer);
-            context.AddSource(filename, SourceText.From(generatedSource, Encoding.UTF8));
-        }
-    }
-
     private static string GetFilename(TypeInfo type, StringBuilder buffer)
     {
         buffer.Clear();

--- a/src/StringLiteralGenerator/Utf8StringLiteralGenerator.Init.cs
+++ b/src/StringLiteralGenerator/Utf8StringLiteralGenerator.Init.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using System.Text;
-
-namespace StringLiteralGenerator;
+﻿namespace StringLiteralGenerator;
 
 public partial class Utf8StringLiteralGenerator
 {
@@ -18,9 +14,4 @@ namespace StringLiteral
     }
 }
 ";
-
-    private static void AddAttribute(IncrementalGeneratorPostInitializationContext context)
-    {
-        context.AddSource("Utf8Attribute", SourceText.From(attributeText, Encoding.UTF8));
-    }
 }

--- a/src/StringLiteralGenerator/Utf8StringLiteralGenerator.Parser.cs
+++ b/src/StringLiteralGenerator/Utf8StringLiteralGenerator.Parser.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
-namespace StringLiteralGenerator;
+﻿namespace StringLiteralGenerator;
 
 public partial class Utf8StringLiteralGenerator
 {

--- a/src/StringLiteralGenerator/Utf8StringLiteralGenerator.cs
+++ b/src/StringLiteralGenerator/Utf8StringLiteralGenerator.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿namespace StringLiteralGenerator;
 
-namespace StringLiteralGenerator;
-
-[Generator]
+[Generator(LanguageNames.CSharp)]
 public partial class Utf8StringLiteralGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -19,5 +16,25 @@ public partial class Utf8StringLiteralGenerator : IIncrementalGenerator
             .Collect();
 
         context.RegisterImplementationSourceOutput(provider, Emit);
+    }
+
+    private static void AddAttribute(IncrementalGeneratorPostInitializationContext context)
+    {
+        context.AddSource("Utf8Attribute", SourceText.From(attributeText, Encoding.UTF8));
+    }
+
+    private static void Emit(SourceProductionContext context, ImmutableArray<Utf8LiteralMethod> methods)
+    {
+        var buffer = new StringBuilder();
+
+        var group = methods.GroupBy(x => x.Type, x => x.Method);
+
+        foreach (var g in group)
+        {
+            var containingType = g.Key;
+            var generatedSource = Generate(containingType, g, buffer);
+            var filename = GetFilename(containingType, buffer);
+            context.AddSource(filename, SourceText.From(generatedSource, Encoding.UTF8));
+        }
     }
 }

--- a/src/StringLiteralGenerator/build/StringLiteralGenerator.targets
+++ b/src/StringLiteralGenerator/build/StringLiteralGenerator.targets
@@ -1,0 +1,12 @@
+<Project>
+	<Target Name="_StringLiteralGeneratorMultiTargetRoslyn3" Condition="'$(SupportsRoslynComponentVersioning)' != 'true'" BeforeTargets="CoreCompile">
+		<ItemGroup>
+			<Analyzer Remove="@(Analyzer)" Condition="$([System.String]::Copy('%(Analyzer.Identity)').IndexOf('StringLiteralGenerator.dll')) &gt;= 0"/>
+		</ItemGroup>
+	</Target>
+	<Target Name="_StringLiteralGeneratorMultiTargetRoslyn4" Condition="'$(SupportsRoslynComponentVersioning)' == 'true'" BeforeTargets="CoreCompile">
+		<ItemGroup>
+			<Analyzer Remove="@(Analyzer)" Condition="$([System.String]::Copy('%(Analyzer.Identity)').IndexOf('StringLiteralGenerator.Roslyn3.dll')) &gt;= 0"/>
+		</ItemGroup>
+	</Target>
+</Project>


### PR DESCRIPTION
Today I found `StringLiteralGenerator` is not referenced as a development-time only source generator but as a normal package.

This PR adds `DevelopmentDependency`.

This PR also enables work in Visual Studio 2019.